### PR TITLE
Support for non async handlers which return nothing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15,7 +15,7 @@ function asyncErrorCatcher(fn) {
         }
 
         var promise = fn.apply(undefined, [req, res, next].concat(rest));
-        if (!promise.catch) return;
+        if (!promise || !promise.catch) return;
         promise.catch(function (err) {
             return next(err);
         });

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export default function asyncErrorCatcher(fn) {
 
     return (req, res, next, ...rest) => {
         const promise = fn(req, res, next, ...rest);
-        if (!promise.catch) return;
+        if (!promise || !promise.catch) return;
         promise.catch(err => next(err));
     };
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -56,6 +56,17 @@ test('should not throw error if non async function is passed in', t => {
     routeWithCatcher(req, res, next);
 });
 
+test('should not throw error if non async function is passed in and returns nothing', t => {
+    function route() {}
+    const routeWithCatcher = catchErrors(route);
+    const req = {};
+    const res = {};
+    const next = () => {
+        t.fail('no error passed');
+    };
+    routeWithCatcher(req, res, next);
+});
+
 test('should handle extra route parameters', async t => {
     function route(req, res, next, param) {
         t.is(param, 'param');


### PR DESCRIPTION
This change allows using this module in a legacy app which also has non-async route handlers which return nothing.